### PR TITLE
Update press.html

### DIFF
--- a/press.html
+++ b/press.html
@@ -76,6 +76,15 @@
     <div class="section grey">
       <div class="container">
       <div class="row">
+      <div class="col-xs-12 col-sm-3 col-lg-2">
+            <p class="press-date">November 17, 2014</p>
+          </div>
+          <div class="col-xs-12 col-sm-9 col-lg-10">
+            <span class="press-source">CryptoCoins News</span>
+            <h4><a href="https://www.cryptocoinsnews.com/factom-whitepaper-released-new-service-leverages-bitcoin-blockchain/" target="_blank" class="press-title link">FACTOM WHITEPAPER RELEASED: NEW SERVICE LEVERAGES BITCOIN BLOCKCHAIN</a></h4>
+          </div>
+        </div>
+        <hr>
           <div class="col-xs-12 col-sm-3 col-lg-2">
             <p class="press-date">November 17, 2014</p>
           </div>
@@ -88,8 +97,6 @@
         <div class="row">
           <div class="col-xs-12 col-sm-3 col-lg-2">
             <p class="press-date">November 8, 2014</p>
-          </div>
-          <div class="col-xs-12 col-sm-9 col-lg-10">
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
             <span class="press-source">CoinTelegraph</span>
@@ -152,7 +159,7 @@
             <p class="press-date">November 3, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="https://www.cryptocoinsnews.com/bitcoin-conference-purdue-university " target="_blank" class="press-title link">Bitcoin Conference At Purdue University</a></h4>
           </div>
         </div>
@@ -162,7 +169,7 @@
             <p class="press-date">October 28, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="https://www.cryptocoinsnews.com/decentralized-storage-application-storj-gets-new-look-opens-closed-beta-access/" target="_blank" class="press-title link">Decentralized Storage Application Storj Gets a New Look and Opens Closed Beta Access to You</a></h4>
           </div>
         </div>
@@ -242,7 +249,7 @@
             <p class="press-date">October 7, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="https://www.cryptocoinsnews.com/dapps-interview" target="_blank" class="press-title link">Interview With Dapps Fund Managing Partner Sam Yilmaz</a></h4>
           </div>
         </div>
@@ -282,7 +289,7 @@
             <p class="press-date">September 15, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="http://www.cryptocoinsnews.com/storjcoin-price-rises-62-in-wake-of-celebgate-apple-hack" target="_blank" class="press-title link">Storjcoin Price Tises 62% in Wake of Celebgate Apple Hack</a></h4>
           </div>
         </div>
@@ -452,7 +459,7 @@
             <p class="press-date">August 22, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="http://www.cryptocoinsnews.com/news/storj-exclusive-interview-decentralized-cloud-storage/2014/08/22" target="_blank" class="press-title link">Storj Exclusive Interview – Decentralized Cloud Storage  </a></h4>
           </div>
         </div>
@@ -502,7 +509,7 @@
             <p class="press-date">August 16, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="http://www.cryptocoinsnews.com/news/storj-head-dev-shawn-wilkinson/2014/08/16" target="_blank" class="press-title link">Storj Head Dev Shawn Wilkinson Hosts Q&A </a></h4>
           </div>
         </div>
@@ -582,7 +589,7 @@
             <p class="press-date">April 11, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
-            <span class="press-source">Crypto Coins News</span>
+            <span class="press-source">CryptoCoins News</span>
             <h4><a href="http://www.cryptocoinsnews.com/news/storj-next-generation-cloud-storage-through-the-blockchain/2014/04/11" target="_blank" class="press-title link">Storj: Next-generation cloud storage through the blockchain </a></h4>
           </div>
         </div>

--- a/press.html
+++ b/press.html
@@ -75,8 +75,8 @@
     </div>
     <div class="section grey">
       <div class="container">
-      <div class="row">
-      <div class="col-xs-12 col-sm-3 col-lg-2">
+        <div class="row">
+          <div class="col-xs-12 col-sm-3 col-lg-2">
             <p class="press-date">November 17, 2014</p>
           </div>
           <div class="col-xs-12 col-sm-9 col-lg-10">
@@ -85,6 +85,7 @@
           </div>
         </div>
         <hr>
+        <div class="row">
           <div class="col-xs-12 col-sm-3 col-lg-2">
             <p class="press-date">November 17, 2014</p>
           </div>


### PR DESCRIPTION
Removed extra <div> for Nov 8. And added latest article for November 17th. Crypto Coins News brand reads as CryptoCoins News,  as shown on their logo, updated list accordingly.
